### PR TITLE
Correct a typing error

### DIFF
--- a/play/ui/json/paging_2.js
+++ b/play/ui/json/paging_2.js
@@ -1,4 +1,4 @@
-jui.ready([ "ui.paging", "uix.xtable" ], function(paging, xtable) {
+jui.ready([ "ui.paging", "grid.xtable" ], function(paging, xtable) {
     paging_2 = paging("#paging_2", {
         pageCount: 100,
         event: {


### PR DESCRIPTION
UI Play의 Paging 안에 있는 Use the paging on the table 항목의 javascript 코드가 오타가 난 것 같아서 수정했습니다.

나머지 javascript는 기존의 uix를 grid로 변경하신 것 같은데, 여기만 uix로 되어있어서 실행이 안되네요.

``` javascript
jui.ready([ "ui.paging", "uix.xtable" ], function(paging, xtable) {
```

``` javascript
jui.ready([ "ui.paging", "grid.xtable" ], function(paging, xtable) {
```
